### PR TITLE
📖 [Docs]: README pages now use the standard module landing-page format

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Telemetry is intended to be a PowerShell module for managing and registering tel
 
 This repository is currently a placeholder. The module source still contains scaffold code, so there are no supported commands or usage examples to document yet.
 
+## Documentation
+
+When this module is implemented, command details should live in PowerShell help and generated documentation rather than being duplicated in this README.
+
 ## Contributing
 
 Issues and pull requests are welcome when implementation work begins.

--- a/README.md
+++ b/README.md
@@ -1,69 +1,11 @@
-# {{ NAME }}
+# Telemetry
 
-{{ DESCRIPTION }}
+Telemetry is intended to be a PowerShell module for managing and registering telemetry.
 
-## Prerequisites
+## Status
 
-This uses the following external resources:
-- The [PSModule framework](https://github.com/PSModule) for building, testing and publishing the module.
-
-## Installation
-
-To install the module from the PowerShell Gallery, you can use the following command:
-
-```powershell
-Install-PSResource -Name {{ NAME }}
-Import-Module -Name {{ NAME }}
-```
-
-## Usage
-
-Here is a list of example that are typical use cases for the module.
-
-### Example 1: Greet an entity
-
-Provide examples for typical commands that a user would like to do with the module.
-
-```powershell
-Greet-Entity -Name 'World'
-Hello, World!
-```
-
-### Example 2
-
-Provide examples for typical commands that a user would like to do with the module.
-
-```powershell
-Import-Module -Name PSModuleTemplate
-```
-
-### Find more examples
-
-To find more examples of how to use the module, please refer to the [examples](examples) folder.
-
-Alternatively, you can use the Get-Command -Module 'This module' to find more commands that are available in the module.
-To find examples of each of the commands you can use Get-Help -Examples 'CommandName'.
-
-## Documentation
-
-Link to further documentation if available, or describe where in the repository users can find more detailed documentation about
-the module's functions and features.
+This repository is currently a placeholder. The module source still contains scaffold code, so there are no supported commands or usage examples to document yet.
 
 ## Contributing
 
-Coder or not, you can contribute to the project! We welcome all contributions.
-
-### For Users
-
-If you don't code, you still sit on valuable information that can make this project even better. If you experience that the
-product does unexpected things, throw errors or is missing functionality, you can help by submitting bugs and feature requests.
-Please see the issues tab on this project and submit a new issue that matches your needs.
-
-### For Developers
-
-If you do code, we'd love to have your contributions. Please read the [Contribution guidelines](CONTRIBUTING.md) for more information.
-You can either help by picking up an existing issue or submit a new one if you have an idea for a new feature or improvement.
-
-## Acknowledgements
-
-Here is a list of people and projects that helped this project in some way.
+Issues and pull requests are welcome when implementation work begins.


### PR DESCRIPTION
README pages now act as concise landing pages. Implemented modules point users to installation, psmodule.io, and PowerShell help instead of duplicating command reference content. Placeholder and in-progress modules now state their status clearly so users are not shown scaffold examples as working usage.

> ⚠️ This PR has no linked issue. Consider creating one for traceability.

## Changed: README pages defer to generated documentation

Implemented module READMEs now provide a short overview, installation commands, and links to generated documentation. Command usage remains in PowerShell help and generated docs.

```powershell
Get-Command -Module <ModuleName>
Get-Help -Name 'CommandName' -Examples
```

## Changed: Placeholder modules identify their status

Repositories that still contain scaffold or stub module code now say they are placeholders or in progress instead of showing template commands as if they worked.

## Technical Details

- Updates `README.md` only.
- Aligns repository READMEs with the default introduced in `PSModule/Template-PSModule`.
- Keeps command-level details out of README pages to avoid duplicating generated module documentation.
